### PR TITLE
typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ the web page. You can leave it out in case you don't want to build the slides or
 
 If you cloned without recursive and need the submodules, run
 ```
-git submodules update --init --recursive
+cd school2021
+git submodule update --init --recursive
 ```
 
 ### Setup the conda environment


### PR DESCRIPTION
 - `git submodule` is without `s`
 - Not specifying that the `git submodule update` should be done inside the `school2021` folder might be a bit misleading for new git users (I was following literally step by step the instructions)