### PR TITLE
Add Git installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,25 @@ conda update -n base --all
 ### Install Git
 
 In case you don't have Git installed (try to execute `git` in your terminal to
-check), [go to git-scm.com](http://www.git-scm.com/download) and follow the
-installation procedure.
+check), you should install it first.
+
+#### Linux
+Use your distribution's package manager to install the `git` package. E.g. on Ubuntu:
+
+```
+$ sudo apt-get update
+$ sudo apt-get install git
+```
+
+#### macOS
+
+Install the XCode Command Line Tools to get git by running this command in a terminal:
+```
+$ xcode-select --install
+```
+
+#### Windows
+[go to git-scm.com](http://www.git-scm.com/download), download the windows installer and follow the installation procedure.
 
 ### clone the repository
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ If you had already installed anaconda in the past, you might want to update it:
 conda update -n base --all
 ```
 
+### Install Git
+
+In case you don't have Git installed (try to execute `git` in your terminal to
+check), [go to git-scm.com](http://www.git-scm.com/download) and follow the
+installation procedure.
+
 ### clone the repository
 
 Open a terminal and go to your working directory


### PR DESCRIPTION
We had a user who had troubles following the instruction because Git was not installed in their system (Windows 10, Powershell). This adds a few lines which show where to get Git.