### PR TITLE
Add <more> separator back in git post

### DIFF
--- a/docs/content/posts/clase04.md
+++ b/docs/content/posts/clase04.md
@@ -1,5 +1,5 @@
 ---
-title: Git & CI - I
+title: Version Control using Git & CI
 date: 2021-05-09T10:00:00
 lastmod: 2021-05-09T10:00:00
 author: Maximilian Nöthe
@@ -12,6 +12,8 @@ categories:
 tags:
   - Day 2
 ---
+
+<!--more-->
 
 # Version Control using Git
 


### PR DESCRIPTION
Fixes that the full post is displayed on the homepage