### PR TITLE
Added .bat files for spark container install

### DIFF
--- a/spark/README.md
+++ b/spark/README.md
@@ -40,8 +40,13 @@ For the last session, we will finish with concrete applications in the domain of
 
 As Spark needs a specific environment, the best way is to use Docker. We provide a Dockerfile in the repo to build the image. From the `spark/` folder of the school repository, execute the build script:
 
+* Linux/MacOS
 ```bash
 ./build_image.sh
+```
+* Windows
+```bat
+./build_image.bat
 ```
 
 The first time, it will download the `jupyter/pyspark-notebook:spark-3.1.1` image (1.2GB compressed, ~3.5GB uncompressed on disk), and install the necessary dependencies. It will also perform a test of the installation by printing some information at the end:
@@ -81,8 +86,16 @@ Jupyter RISE add-ons
 
 Use the provided runner to launch notebooks from the inside of the container:
 
+* Linux/MacOS
 ```bash
 ./launch_notebooks.sh
+```
+* Windows
+```bat
+./launch_notebooks.bat
+```
+
+```bash
 ...
 [I 06:51:48.032 NotebookApp] Serving notebooks from local directory: /home/jovyan/work
 [I 06:51:48.032 NotebookApp] Jupyter Notebook 6.4.0 is running at:
@@ -98,8 +111,15 @@ Copy the generated URL in your browser tab, and walk to the notebook folder. The
 
 To enter the container and fully enjoy all Spark features, you would just use the provided runner:
 
+* Linux/MacOS
 ```bash
 ./launch_container.sh
+(base) jovyan@77081e01d859:~/work$
+
+```
+* Windows
+```bat
+./launch_container.bat
 (base) jovyan@77081e01d859:~/work$
 
 ```

--- a/spark/build_image.bat
+++ b/spark/build_image.bat
@@ -1,0 +1,37 @@
+::!/bin/bash
+:: MIT License
+::
+:: Copyright (c) 2021 ESCAPE
+::
+:: Permission is hereby granted, free of charge, to any person obtaining a copy
+:: of this software and associated documentation files (the "Software"), to deal
+:: in the Software without restriction, including without limitation the rights
+:: to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+:: copies of the Software, and to permit persons to whom the Software is
+:: furnished to do so, subject to the following conditions:
+::
+:: The above copyright notice and this permission notice shall be included in all
+:: copies or substantial portions of the Software.
+::
+:: THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+:: IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+:: FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+:: AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+:: LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+:: OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+:: SOFTWARE.
+@echo off
+docker build -t "spark_escape2021" -f Dockerfile .
+
+set SPARKFITS="com.github.astrolabsoftware:spark-fits_2.12:0.9.0"
+
+:: Check installation worked
+docker run -it --rm  ^
+  -v %cd%:/home/jovyan/work:rw -p 8888:8888 -p 4040:4040 -p 18080:18080 ^
+  spark_escape2021 spark-submit --master local[*] ^
+  --driver-memory 2g --executor-memory 2g --packages %SPARKFITS% test_installation.py
+
+:: Run unit tests
+docker run -it --rm  ^
+  -v %cd%:/home/jovyan/work:rw -p 8888:8888 -p 4040:4040 -p 18080:18080 ^
+  spark_escape2021 ./test.sh

--- a/spark/launch_container.bat
+++ b/spark/launch_container.bat
@@ -1,0 +1,29 @@
+::!/bin/bash
+:: MIT License
+::
+:: Copyright (c) 2021 ESCAPE
+::
+:: Permission is hereby granted, free of charge, to any person obtaining a copy
+:: of this software and associated documentation files (the "Software"), to deal
+:: in the Software without restriction, including without limitation the rights
+:: to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+:: copies of the Software, and to permit persons to whom the Software is
+:: furnished to do so, subject to the following conditions:
+::
+:: The above copyright notice and this permission notice shall be included in all
+:: copies or substantial portions of the Software.
+::
+:: THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+:: IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+:: FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+:: AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+:: LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+:: OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+:: SOFTWARE.
+@echo off
+
+:: Enter the container
+docker run -it --rm  ^
+    -v %cd%:/home/jovyan/work:rw ^
+    -p 8888:8888 -p 4040:4040 -p 18080:18080 ^
+    spark_escape2021 bash ^

--- a/spark/launch_notebooks.bat
+++ b/spark/launch_notebooks.bat
@@ -1,0 +1,31 @@
+::!/bin/bash
+:: MIT License
+::
+:: Copyright (c) 2021 ESCAPE
+::
+:: Permission is hereby granted, free of charge, to any person obtaining a copy
+:: of this software and associated documentation files (the "Software"), to deal
+:: in the Software without restriction, including without limitation the rights
+:: to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+:: copies of the Software, and to permit persons to whom the Software is
+:: furnished to do so, subject to the following conditions:
+::
+:: The above copyright notice and this permission notice shall be included in all
+:: copies or substantial portions of the Software.
+::
+:: THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+:: IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+:: FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+:: AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+:: LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+:: OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+:: SOFTWARE.
+@echo off
+set SPARKFITS="com.github.astrolabsoftware:spark-fits_2.12:0.8.4"
+
+:: Run jupyter through Docker
+docker run -it --rm  ^
+    -v %cd%:/home/jovyan/work:rw -p 8888:8888 -p 4040:4040 -p 18080:18080 ^
+    spark_escape2021 /usr/local/spark/bin/pyspark ^
+    --master local[*] --driver-memory 2g --executor-memory 2g ^
+    --packages %SPARKFITS% --conf "spark.pyspark.driver.python=jupyter-notebook"


### PR DESCRIPTION
As asked in the Slack, I created the .bat files from the .sh files for the Spark container installation so that Windows user can use the scripts, also added the commands into the README.md.
I tested the scripts, they run OK on my Windows 10 machine.